### PR TITLE
record,playback: make the scripts a little bit more sensible

### DIFF
--- a/playback
+++ b/playback
@@ -5,11 +5,9 @@ RECFILE="$2"
 shift;shift
 
 mv "$HOME/.mame/cfg/$GAME.cfg"{,~} 2> /dev/null
-mv "$HOME/.mame/nvram/$GAME"{,~} 2> /dev/null
 mv "$HOME/.mame/diff/$GAME.dif"{,~} 2> /dev/null
 
 ./mame "$GAME" -playback "$RECFILE.inp" -noplugin hiscore -nvram_directory /dev/null "$@"
 
 mv "$HOME/.mame/cfg/$GAME.cfg"{~,} 2> /dev/null
-mv "$HOME/.mame/nvram/$GAME"{~,} 2> /dev/null
 mv "$HOME/.mame/diff/$GAME.dif"{~,} 2> /dev/null

--- a/playback
+++ b/playback
@@ -1,11 +1,15 @@
-#!/bin/bash
+#!/bin/sh
 
-mv cfg/$1.cfg cfg/$1.bak
-mv nvram/$1.nv nvram/$1.bak
-mv diff/$1.dif diff/$1.bak
+GAME="$1"
+RECFILE="$2"
+shift;shift
 
-./mame $1 -playback $2.inp $3 $4 $5 $6 $7 $8 $9 -nvram_directory /dev/null
+mv "$HOME/.mame/cfg/$GAME.cfg"{,~} 2> /dev/null
+mv "$HOME/.mame/nvram/$GAME"{,~} 2> /dev/null
+mv "$HOME/.mame/diff/$GAME.dif"{,~} 2> /dev/null
 
-mv cfg/$1.bak cfg/$1.cfg
-mv nvram/$1.bak nvram/$1.nv
-mv diff/$1.bak diff/$1.dif
+./mame "$GAME" -playback "$RECFILE.inp" -noplugin hiscore -nvram_directory /dev/null "$@"
+
+mv "$HOME/.mame/cfg/$GAME.cfg"{~,} 2> /dev/null
+mv "$HOME/.mame/nvram/$GAME"{~,} 2> /dev/null
+mv "$HOME/.mame/diff/$GAME.dif"{~,} 2> /dev/null

--- a/record
+++ b/record
@@ -5,11 +5,9 @@ RECFILE="$2"
 shift;shift
 
 mv "$HOME/.mame/cfg/$GAME.cfg"{,~} 2> /dev/null
-mv "$HOME/.mame/nvram/$GAME"{,~} 2> /dev/null
 mv "$HOME/.mame/diff/$GAME.dif"{,~} 2> /dev/null
 
 ./mame "$GAME" -record "$RECFILE.inp" -noplugin hiscore -nvram_directory /dev/null "$@"
 
 mv "$HOME/.mame/cfg/$GAME.cfg"{~,} 2> /dev/null
-mv "$HOME/.mame/nvram/$GAME"{~,} 2> /dev/null
 mv "$HOME/.mame/diff/$GAME.dif"{~,} 2> /dev/null

--- a/record
+++ b/record
@@ -1,11 +1,15 @@
-#!/bin/bash
+#!/bin/sh
 
-mv cfg/$1.cfg cfg/$1.bak
-mv nvram/$1.nv nvram/$1.bak
-mv diff/$1.dif diff/$1.bak
+GAME="$1"
+RECFILE="$2"
+shift;shift
 
-./mame $1 -record $2.inp $3 $4 $5 $6 $7 $8 $9 -nvram_directory /dev/null
+mv "$HOME/.mame/cfg/$GAME.cfg"{,~} 2> /dev/null
+mv "$HOME/.mame/nvram/$GAME"{,~} 2> /dev/null
+mv "$HOME/.mame/diff/$GAME.dif"{,~} 2> /dev/null
 
-mv cfg/$1.bak cfg/$1.cfg
-mv nvram/$1.bak nvram/$1.nv
-mv diff/$1.bak diff/$1.dif
+./mame "$GAME" -record "$RECFILE.inp" -noplugin hiscore -nvram_directory /dev/null "$@"
+
+mv "$HOME/.mame/cfg/$GAME.cfg"{~,} 2> /dev/null
+mv "$HOME/.mame/nvram/$GAME"{~,} 2> /dev/null
+mv "$HOME/.mame/diff/$GAME.dif"{~,} 2> /dev/null


### PR DESCRIPTION
* No bash features are used in the scripts, just launch /bin/sh instead.

* Instead of enumerating up to nine command line paramters, just grab $1 and $2 specially and pass everything onto the MAME command.

* Add "-noplugin hiscore" to prevent this plugin from creating desyncs, if the plugin is normally enabled in the MAME configuration.

* MAME on Unix doesn't store config in the current directory, but $HOME/.mame instead.  Use those paths for backing up and restoring configuration files.